### PR TITLE
frontend: use relative API base fallback

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,10 @@
+# Example environment configuration for the Fitbit2Garmin frontend.
+# Copy this file to `.env` and adjust values as needed.
+
+# Override the backend API URL when running the UI against a different
+# server during local development. Leave unset to use the same origin's
+# "/api" path exposed by the dev proxy.
+# Examples:
+#   REACT_APP_API_URL=http://localhost:8000
+#   REACT_APP_API_URL=https://staging.example.com/api
+REACT_APP_API_URL=

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -6,7 +6,10 @@ import axios from 'axios';
 import { FingerprintData } from './fingerprint';
 
 // Configure API base URL (update for production)
-const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+const defaultApiBaseUrl =
+  typeof window !== 'undefined' ? `${window.location.origin}/api` : '/api';
+const rawApiBaseUrl = process.env.REACT_APP_API_URL || defaultApiBaseUrl;
+const API_BASE_URL = rawApiBaseUrl.replace(/\/+$/, '');
 
 const api = axios.create({
   baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary
- default the frontend API base URL to the app origin `/api` path when no override is provided
- trim trailing slashes so helper methods such as download URLs build correctly with relative bases
- add a `.env.example` documenting how to override `REACT_APP_API_URL` for alternate backends

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc6e04b85c8326841a0f17139cdfd3