### PR TITLE
Fix Vercel 404 by adjusting analytics imports and distDir

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,8 +3,8 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { Analytics } from "@vercel/analytics/next";
-import { SpeedInsights } from "@vercel/speed-insights/next";
+import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/react";
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import { FileUpload } from './components/FileUpload';
 import { ConversionProgress } from './components/ConversionProgress';

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "builds": [
-    { "src": "frontend/package.json", "use": "@vercel/static-build", "config": { "distDir": "build" } },
+    { "src": "frontend/package.json", "use": "@vercel/static-build", "config": { "distDir": "frontend/build" } },
     { "src": "backend/api/index.py", "use": "@vercel/python" }
   ],
   "routes": [


### PR DESCRIPTION
## Summary
- switch Vercel analytics and speed insights imports to the React entrypoints so the CRA build succeeds
- update the static build configuration so Vercel serves files from the frontend build directory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc76eeaca88326a6a2f36d117873af