### PR TITLE
Ensure CRA build output is available at repo root for Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .env.production.local
 
 # Build outputs
+build/
 frontend/build/
 backend/.vercel/
 .vercel/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "node scripts/build.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/frontend/scripts/build.js
+++ b/frontend/scripts/build.js
@@ -1,0 +1,44 @@
+const path = require('path');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+const frontendDir = path.resolve(__dirname, '..');
+const buildScript = require.resolve('react-scripts/scripts/build');
+
+const result = spawnSync('node', [buildScript], { stdio: 'inherit' });
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}
+
+const sourceDir = path.join(frontendDir, 'build');
+const outputDir = path.resolve(frontendDir, '..', 'build');
+
+const copyDirectory = (from, to) => {
+  const entries = fs.readdirSync(from, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const sourcePath = path.join(from, entry.name);
+    const targetPath = path.join(to, entry.name);
+
+    if (entry.isDirectory()) {
+      fs.mkdirSync(targetPath, { recursive: true });
+      copyDirectory(sourcePath, targetPath);
+    } else if (entry.isSymbolicLink()) {
+      const linkTarget = fs.readlinkSync(sourcePath);
+      fs.symlinkSync(linkTarget, targetPath);
+    } else {
+      fs.copyFileSync(sourcePath, targetPath);
+    }
+  }
+};
+
+fs.rmSync(outputDir, { recursive: true, force: true });
+fs.mkdirSync(outputDir, { recursive: true });
+if (!fs.existsSync(sourceDir)) {
+  console.error(`Expected build output at ${sourceDir} but it was not found.`);
+  process.exit(1);
+}
+copyDirectory(sourceDir, outputDir);
+
+console.log(`Copied production build to ${path.relative(frontendDir, outputDir) || '.'}`);

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "builds": [
-    { "src": "frontend/package.json", "use": "@vercel/static-build", "config": { "distDir": "frontend/build" } },
+    { "src": "frontend/package.json", "use": "@vercel/static-build", "config": { "distDir": "build" } },
     { "src": "backend/api/index.py", "use": "@vercel/python" }
   ],
   "routes": [


### PR DESCRIPTION
## Summary
- add a custom build script that runs CRA's build and copies the artifacts to the repository root for deployment
- ignore the new build directory and update the Vercel config to reference it

## Testing
- npm run build (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68cc7a3ea97c8326bff5cfde1374e3d7