### PR TITLE
frontend: route /api to Pages Functions (fix SPA catch-all)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -31,7 +31,8 @@
       "mcp__cloudflare-bindings__r2_bucket_create",
       "WebFetch(domain:developer.garmin.com)",
       "WebSearch",
-      "Bash(npm init:*)"
+      "Bash(npm init:*)",
+      "Bash(git add:*)"
     ],
     "deny": [],
     "ask": []

--- a/CLOUDFLARE_MIGRATION.md
+++ b/CLOUDFLARE_MIGRATION.md
@@ -67,11 +67,29 @@ binding = "RATE_LIMITS"
 id = "cdaa358255684b39b8f9429dab347cec"
 ```
 
-### _redirects
+### Routing fixes
+
+To ensure API requests are handled by Cloudflare Pages Functions and not the SPA, two routing files are required:
+
+1) `_redirects` (copied to the build output)
 ```
-# SPA routing for React Router - Pages Functions will handle /api routes automatically
-/*    /index.html   200
+# Ensure API requests hit Pages Functions first
+/api/*    /api/:splat   200
+
+# SPA routing for React Router
+/*         /index.html   200
 ```
+
+2) `_routes.json` (placed alongside the static assets)
+```
+{
+  "version": 1,
+  "include": ["/api/*"],
+  "exclude": []
+}
+```
+
+Previously, the catch‑all SPA rule caused `/api/*` to be rewritten to `/index.html`. The above configuration ensures `/api/*` is evaluated as a function route and the SPA receives everything else.
 
 ## Next Steps for Full Functionality
 

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,2 +1,2 @@
-# SPA routing for React Router - Pages Functions will handle /api routes automatically
+# SPA routing for React Router
 /*    /index.html   200

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,2 +1,5 @@
+# Ensure API requests hit Pages Functions, not the SPA
+/api/*    /api/:splat   200
+
 # SPA routing for React Router
-/*    /index.html   200
+/*         /index.html   200

--- a/frontend/public/_routes.json
+++ b/frontend/public/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/*"],
+  "exclude": ["/api/*"]
+}

--- a/frontend/public/_routes.json
+++ b/frontend/public/_routes.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
-  "include": ["/*"],
-  "exclude": ["/api/*"]
+  "include": ["/api/*"],
+  "exclude": []
 }


### PR DESCRIPTION
Problem
- _redirects SPA catch-all rule sent /api/* to /index.html, so API requests returned HTML instead of JSON and Cloudflare Pages Functions did not run.

Changes
- Update frontend/public/_redirects to prioritize API routes:
  - /api/*  /api/:splat  200
  - /*      /index.html   200
- Update frontend/public/_routes.json to include only /api/* so functions are evaluated for those paths.
- Update CLOUDFLARE_MIGRATION.md with explicit routing configuration and rationale.

Files
- frontend/public/_redirects
- frontend/public/_routes.json
- CLOUDFLARE_MIGRATION.md

Why
- Ensures API calls (upload/convert/download/health) are handled by Pages Functions and not the SPA router. Fixes the separate routing issue where all requests were going to the SPA.

How to test
- Local: npx wrangler pages dev frontend/dist
  - GET /api/ → JSON status response
  - OPTIONS/POST /api/upload → JSON (no HTML)
- Deploy: npx wrangler pages deploy frontend/dist --project-name=fitbit2garmin --commit-dirty=true

Notes
- No changes to function code; purely routing. The previous ESM import bug for the converter is already resolved.