### PR TITLE
Add disclaimer footer to measurements page

### DIFF
--- a/frontend/src/pages/measurements/index.tsx
+++ b/frontend/src/pages/measurements/index.tsx
@@ -109,6 +109,9 @@ export default function MeasurementsPage() {
               <span>Powered by Cloudflare</span>
             </div>
           </div>
+          <div className="mt-4 pt-4 border-t border-gray-200 text-xs text-gray-400 text-center">
+            Independent tool. Not affiliated with Garmin, Fitbit, or Google. Garmin, Fitbit, and Google are trademarks of their respective owners. Mentions are for compatibility only.
+          </div>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
## Summary
- Added legal disclaimer footer to the measurements page
- States the tool is independent and not affiliated with Garmin, Fitbit, or Google
- Includes proper trademark acknowledgment for compatibility mentions

## Changes
- Added disclaimer text below existing footer content
- Styled with appropriate typography (small, gray, centered)
- Maintains visual hierarchy with border separator

## Test plan
- [x] Verify footer displays correctly on measurements page
- [x] Confirm text is readable and properly styled
- [x] Check responsive layout

🤖 Generated with [Claude Code](https://claude.ai/code)